### PR TITLE
esp32/machine_pwm: Implement duty_u16() and duty_ns() PWM methods.

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -218,20 +218,24 @@ range from 1Hz to 40MHz but there is a tradeoff; as the base frequency
 *increases* the duty resolution *decreases*. See
 `LED Control <https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/peripherals/ledc.html>`_
 for more details.
-Currently the duty cycle has to be in the range of 0-1023.
 
-Use the ``machine.PWM`` class::
+Use the :ref:`machine.PWM <machine.PWM>` class::
 
     from machine import Pin, PWM
 
-    pwm0 = PWM(Pin(0))      # create PWM object from a pin
-    pwm0.freq()             # get current frequency (default 5kHz)
-    pwm0.freq(1000)         # set frequency
-    pwm0.duty()             # get current duty cycle (default 512, 50%)
-    pwm0.duty(200)          # set duty cycle
-    pwm0.deinit()           # turn off PWM on the pin
+    pwm0 = PWM(Pin(0))         # create PWM object from a pin
+    pwm0.freq()                # get current frequency (default 5kHz)
+    pwm0.freq(1000)            # set PWM frequency from 1Hz to 40MHz
+    pwm0.duty()                # get current duty cycle, range 0-1023 (default 512, 50%)
+    pwm0.duty(256)             # set duty cycle from 0 to 1023 as a ratio duty/1023, (now 25%)
+    pwm0.duty_u16(2**16*3//4)  # set duty cycle from 0 to 65535 as a ratio duty_u16/65535, (now 75%)
+    pwm0.duty_u16()            # get current duty cycle, range 0-65535
+    pwm0.duty_ns(250_000)      # set pulse width in nanoseconds from 0 to 1_000_000_000/freq, (now 25%)
+    pwm0.duty_ns()             # get current pulse width in ns
+    pwm0.deinit()              # turn off PWM on the pin
 
     pwm2 = PWM(Pin(2), freq=20000, duty=512)  # create and configure in one go
+    print(pwm2)                               # view PWM settings
 
 ESP chips have different hardware peripherals:
 
@@ -250,6 +254,8 @@ A maximum number of PWM channels (Pins) are available on the ESP32 - 16 channels
 but only 8 different PWM frequencies are available, the remaining 8 channels must
 have the same frequency.  On the other hand, 16 independent PWM duty cycles are
 possible at the same frequency.
+
+See more examples in the :ref:`esp32_pwm` tutorial.
 
 ADC (analog to digital conversion)
 ----------------------------------

--- a/docs/esp32/tutorial/pwm.rst
+++ b/docs/esp32/tutorial/pwm.rst
@@ -1,4 +1,4 @@
-.. _esp32_pwm: 
+.. _esp32_pwm:
 
 Pulse Width Modulation
 ======================
@@ -11,7 +11,7 @@ compared with the length of a single period (low plus high time).  Maximum
 duty cycle is when the pin is high all of the time, and minimum is when it is
 low all of the time.
 
-More comprehensive example with all 16 PWM channels and 8 timers::
+* More comprehensive example with all 16 PWM channels and 8 timers::
 
     from machine import Pin, PWM
     try:
@@ -29,21 +29,87 @@ More comprehensive example with all 16 PWM channels and 8 timers::
             except:
                 pass
 
-Output is::
+  Output is::
 
-    PWM(pin=15, freq=100, duty=64, resolution=10, mode=0, channel=0, timer=0)
-    PWM(pin=2, freq=100, duty=128, resolution=10, mode=0, channel=1, timer=0)
-    PWM(pin=4, freq=200, duty=192, resolution=10, mode=0, channel=2, timer=1)
-    PWM(pin=16, freq=200, duty=256, resolution=10, mode=0, channel=3, timer=1)
-    PWM(pin=18, freq=300, duty=320, resolution=10, mode=0, channel=4, timer=2)
-    PWM(pin=19, freq=300, duty=384, resolution=10, mode=0, channel=5, timer=2)
-    PWM(pin=22, freq=400, duty=448, resolution=10, mode=0, channel=6, timer=3)
-    PWM(pin=23, freq=400, duty=512, resolution=10, mode=0, channel=7, timer=3)
-    PWM(pin=25, freq=500, duty=576, resolution=10, mode=1, channel=0, timer=0)
-    PWM(pin=26, freq=500, duty=640, resolution=10, mode=1, channel=1, timer=0)
-    PWM(pin=27, freq=600, duty=704, resolution=10, mode=1, channel=2, timer=1)
-    PWM(pin=14, freq=600, duty=768, resolution=10, mode=1, channel=3, timer=1)
-    PWM(pin=12, freq=700, duty=832, resolution=10, mode=1, channel=4, timer=2)
-    PWM(pin=13, freq=700, duty=896, resolution=10, mode=1, channel=5, timer=2)
-    PWM(pin=32, freq=800, duty=960, resolution=10, mode=1, channel=6, timer=3)
-    PWM(pin=33, freq=800, duty=1023, resolution=10, mode=1, channel=7, timer=3)
+    PWM(Pin(15), freq=100, duty=64, resolution=10, mode=0, channel=0, timer=0)
+    PWM(Pin(2), freq=100, duty=128, resolution=10, mode=0, channel=1, timer=0)
+    PWM(Pin(4), freq=200, duty=192, resolution=10, mode=0, channel=2, timer=1)
+    PWM(Pin(16), freq=200, duty=256, resolution=10, mode=0, channel=3, timer=1)
+    PWM(Pin(18), freq=300, duty=320, resolution=10, mode=0, channel=4, timer=2)
+    PWM(Pin(19), freq=300, duty=384, resolution=10, mode=0, channel=5, timer=2)
+    PWM(Pin(22), freq=400, duty=448, resolution=10, mode=0, channel=6, timer=3)
+    PWM(Pin(23), freq=400, duty=512, resolution=10, mode=0, channel=7, timer=3)
+    PWM(Pin(25), freq=500, duty=576, resolution=10, mode=1, channel=0, timer=0)
+    PWM(Pin(26), freq=500, duty=640, resolution=10, mode=1, channel=1, timer=0)
+    PWM(Pin(27), freq=600, duty=704, resolution=10, mode=1, channel=2, timer=1)
+    PWM(Pin(14), freq=600, duty=768, resolution=10, mode=1, channel=3, timer=1)
+    PWM(Pin(12), freq=700, duty=832, resolution=10, mode=1, channel=4, timer=2)
+    PWM(Pin(13), freq=700, duty=896, resolution=10, mode=1, channel=5, timer=2)
+    PWM(Pin(32), freq=800, duty=960, resolution=10, mode=1, channel=6, timer=3)
+    PWM(Pin(33), freq=800, duty=1023, resolution=10, mode=1, channel=7, timer=3)
+
+* Example of a smooth frequency change::
+
+    from utime import sleep
+    from machine import Pin, PWM
+
+    F_MIN = 500
+    F_MAX = 1000
+
+    f = F_MIN
+    delta_f = 1
+
+    p = PWM(Pin(5), f)
+    print(p)
+
+    while True:
+        p.freq(f)
+
+        sleep(10 / F_MIN)
+
+        f += delta_f
+        if f >= F_MAX or f <= F_MIN:
+            delta_f = -delta_f
+
+  See PWM wave at Pin(5) with an oscilloscope.
+
+* Example of a smooth duty change::
+
+    from utime import sleep
+    from machine import Pin, PWM
+
+    DUTY_MAX = 2**16 - 1
+
+    duty_u16 = 0
+    delta_d = 16
+
+    p = PWM(Pin(5), 1000, duty_u16=duty_u16)
+    print(p)
+
+    while True:
+        p.duty_u16(duty_u16)
+
+        sleep(1 / 1000)
+
+        duty_u16 += delta_d
+        if duty_u16 >= DUTY_MAX:
+            duty_u16 = DUTY_MAX
+            delta_d = -delta_d
+        elif duty_u16 <= 0:
+            duty_u16 = 0
+            delta_d = -delta_d
+
+  See PWM wave at Pin(5) with an oscilloscope.
+
+Note: the Pin.OUT mode does not need to be specified.  The channel is initialized
+to PWM mode internally once for each Pin that is passed to the PWM constructor.
+
+The following code is wrong::
+
+    pwm = PWM(Pin(5, Pin.OUT), freq=1000, duty=512)  # Pin(5) in PWM mode here
+    pwm = PWM(Pin(5, Pin.OUT), freq=500, duty=256)  # Pin(5) in OUT mode here, PWM is off
+
+Use this code instead::
+
+    pwm = PWM(Pin(5), freq=1000, duty=512)
+    pwm.init(freq=500, duty=256)

--- a/docs/library/machine.PWM.rst
+++ b/docs/library/machine.PWM.rst
@@ -77,3 +77,34 @@ Methods
    With no arguments the pulse width in nanoseconds is returned.
 
    With a single *value* argument the pulse width is set to that value.
+
+Limitations of PWM
+------------------
+
+* Not all frequencies can be generated with absolute accuracy due to
+  the discrete nature of the computing hardware.  Typically the PWM frequency
+  is obtained by dividing some integer base frequency by an integer divider.
+  For example, if the base frequency is 80MHz and the required PWM frequency is
+  300kHz the divider must be a non-integer number 80000000 / 300000 = 266.67.
+  After rounding the divider is set to 267 and the PWM frequency will be
+  80000000 / 267 = 299625.5 Hz, not 300kHz.  If the divider is set to 266 then
+  the PWM frequency will be 80000000 / 266 = 300751.9 Hz, but again not 300kHz.
+
+* The duty cycle has the same discrete nature and its absolute accuracy is not
+  achievable.  On most hardware platforms the duty will be applied at the next
+  frequency period.  Therefore, you should wait more than "1/frequency" before
+  measuring the duty.
+
+* The frequency and the duty cycle resolution are usually interdependent.
+  The higher the PWM frequency the lower the duty resolution which is available,
+  and vice versa. For example, a 300kHz PWM frequency can have a duty cycle
+  resolution of 8 bit, not 16-bit as may be expected.  In this case, the lowest
+  8 bits of *duty_u16* are insignificant. So::
+
+    pwm=PWM(Pin(13), freq=300_000, duty_u16=2**16//2)
+
+  and::
+
+    pwm=PWM(Pin(13), freq=300_000, duty_u16=2**16//2 + 255)
+
+  will generate PWM with the same 50% duty cycle.

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -193,6 +193,8 @@ soft_reset_exit:
     mp_hal_stdout_tx_str("MPY: soft reboot\r\n");
 
     // deinitialise peripherals
+    machine_pwm_deinit_all();
+    // TODO: machine_rmt_deinit_all();
     machine_pins_deinit();
     machine_deinit();
     usocket_events_deinit();

--- a/ports/esp32/modmachine.h
+++ b/ports/esp32/modmachine.h
@@ -26,6 +26,8 @@ void machine_init(void);
 void machine_deinit(void);
 void machine_pins_init(void);
 void machine_pins_deinit(void);
+void machine_pwm_deinit_all(void);
+// TODO: void machine_rmt_deinit_all(void);
 void machine_timer_deinit_all(void);
 void machine_i2s_init0();
 

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -165,6 +165,7 @@
 #define MICROPY_PY_MACHINE_PWM              (1)
 #define MICROPY_PY_MACHINE_PWM_INIT         (1)
 #define MICROPY_PY_MACHINE_PWM_DUTY         (1)
+#define MICROPY_PY_MACHINE_PWM_DUTY_U16_NS  (1)
 #define MICROPY_PY_MACHINE_PWM_INCLUDEFILE  "ports/esp32/machine_pwm.c"
 #define MICROPY_PY_MACHINE_I2C              (1)
 #define MICROPY_PY_MACHINE_SOFTI2C          (1)


### PR DESCRIPTION
The methods duty_u16() and duty_ns() are implemented to match the existing
docs.  The duty will remain the same when the frequency is changed.
Standard ESP32 as well as S2, S3 and C3 are supported.

Thanks to @kdschlosser for the fix for rounding in resolution calculation.

Documentation is updated and examples expanded for esp32, including the
quickref and tutorial.  Additional notes are added to the machine.PWM docs
regarding limitations of hardware PWM.